### PR TITLE
Uncomment `wp_footer` function in footer.php

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -222,6 +222,6 @@
 
 
         <div id="fb-root"></div>
-        <?php // wp_footer(); ?>
+        <?php wp_footer(); ?>
     </body>
 </html>


### PR DESCRIPTION
This will ensure this hook is run, necessary to display the admin bar.

![Screenshot 2020-01-23 at 15 47 26](https://user-images.githubusercontent.com/1951880/72999726-aef91f80-3df7-11ea-82ca-a65fc43dca65.png)

Fixes #1